### PR TITLE
Improve nickname mention accuracy

### DIFF
--- a/channellogger.go
+++ b/channellogger.go
@@ -62,7 +62,9 @@ func (cl *channelLogger) saveUrls(conn *irc.Conn, line *irc.Line) {
 func (cl *channelLogger) saveMentions(conn *irc.Conn, line *irc.Line) {
 	nicksToCheck := cl.site.offlineNicks()
 	for _, n := range nicksToCheck {
-		if strings.Index(line.Text(), n) != -1 {
+		if (strings.Contains(line.Text(), n + ": ") ||
+			strings.Contains(line.Text(), n + " ")
+		) {
 			// offline user was mentioned
 			cl.saveMention(n, line, conn)
 		}


### PR DESCRIPTION
I sent a message that started with "jed21611: ", because that was his
current nickname, and frontdesk sent me a PM saying that "jed2161" is
not currently in the room, and he'll be messaged when he is.

This change should fix that bug, only recognizing a nickname in a message if
it ends with a colon or a space.

I'd like to write some tests for this function but I'm so unfamiliar with go
so far and I haven't looked how to do that yet.
